### PR TITLE
Add a small PHP 8.0 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpunit.result.cache
 /clover.xml
 /composer.lock
 /coveralls-upload.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,38 +12,15 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-      env:
-        - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
-      env:
-        - DEPS=latest
-        - CS_CHECK=true
-        - TEST_COVERAGE=true
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
     - php: 7.3
       env:
         - DEPS=lowest
     - php: 7.3
       env:
         - DEPS=latest
+    - php: 8.0
+      env:
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,41 +15,28 @@ os:
 jobs:
   fast_finish: true
   include:
-    - php: 5.6
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 5.6
+    - php: 7.3
       env:
         - DEPS=latest
-    - php: 7
+    - php: 7.4
       env:
         - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
+    - php: 7.4
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
+    - php: nightly
       env:
         - DEPS=lowest
-    - php: 7.2
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - php: nightly
       env:
         - DEPS=latest
-    - php: 7.3
-      env:
-        - DEPS=lowest
-    - php: 7.3
-      env:
-        - DEPS=latest
-    - php: 8.0
-      env:
-          - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ jobs:
     - php: 7.3
       env:
         - DEPS=latest
+        - CS_CHECK=true
     - php: 7.4
       env:
         - DEPS=lowest
     - php: 7.4
       env:
         - DEPS=latest
-        - CS_CHECK=true
         - TEST_COVERAGE=true
     - php: nightly
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,38 @@ env:
     - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
-matrix:
+os:
+  - linux
+
+jobs:
   fast_finish: true
   include:
+    - php: 5.6
+      env:
+        - DEPS=lowest
+    - php: 5.6
+      env:
+        - DEPS=latest
+    - php: 7
+      env:
+        - DEPS=lowest
+    - php: 7
+      env:
+        - DEPS=latest
+    - php: 7.1
+      env:
+        - DEPS=lowest
+    - php: 7.1
+      env:
+        - DEPS=latest
+        - CS_CHECK=true
+        - TEST_COVERAGE=true
+    - php: 7.2
+      env:
+        - DEPS=lowest
+    - php: 7.2
+      env:
+        - DEPS=latest
     - php: 7.3
       env:
         - DEPS=lowest
@@ -20,7 +49,7 @@ matrix:
         - DEPS=latest
     - php: 8.0
       env:
-        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+          - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     },
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,13 @@
         }
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.3 || ^8.0",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4"
+        "phpunit/phpunit": "^9.4",
+        "ext-iconv": "*"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
+<phpunit 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" 
+    bootstrap="vendor/autoload.php" 
+    colors="true">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+
     <testsuites>
         <testsuite name="laminas-xml Test Suite">
             <directory>./test</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/Security.php
+++ b/src/Security.php
@@ -55,7 +55,9 @@ class Security
         }
 
         if (! self::isPhpFpm()) {
-            $loadEntities = libxml_disable_entity_loader(true);
+            if (\PHP_VERSION_ID < 80000) {
+                $loadEntities = libxml_disable_entity_loader(true);
+            }
             $useInternalXmlErrors = libxml_use_internal_errors(true);
         }
 
@@ -75,7 +77,9 @@ class Security
         if (! $result) {
             // Entity load to previous setting
             if (! self::isPhpFpm()) {
-                libxml_disable_entity_loader($loadEntities);
+                if (\PHP_VERSION_ID < 80000) {
+                    libxml_disable_entity_loader($loadEntities);
+                }
                 libxml_use_internal_errors($useInternalXmlErrors);
             }
             return false;
@@ -94,7 +98,9 @@ class Security
 
         // Entity load to previous setting
         if (! self::isPhpFpm()) {
-            libxml_disable_entity_loader($loadEntities);
+            if (\PHP_VERSION_ID < 80000) {
+                libxml_disable_entity_loader($loadEntities);
+            }
             libxml_use_internal_errors($useInternalXmlErrors);
         }
 

--- a/test/SecurityTest.php
+++ b/test/SecurityTest.php
@@ -19,37 +19,37 @@ class SecurityTest extends TestCase
     /**
      * @expectedException Laminas\Xml\Exception\RuntimeException
      */
-    public function testScanForXEE()
+    public function testScanForXEE(): void
     {
         $xml = <<<XML
-<?xml version="1.0"?>
-<!DOCTYPE results [<!ENTITY harmless "completely harmless">]>
-<results>
-    <result>This result is &harmless;</result>
-</results>
-XML;
+            <?xml version="1.0"?>
+            <!DOCTYPE results [<!ENTITY harmless "completely harmless">]>
+            <results>
+                <result>This result is &harmless;</result>
+            </results>
+            XML;
 
         $this->expectException('Laminas\Xml\Exception\RuntimeException');
-        $result = XmlSecurity::scan($xml);
+        XmlSecurity::scan($xml);
     }
 
-    public function testScanForXXE()
+    public function testScanForXXE(): void
     {
         $file = tempnam(sys_get_temp_dir(), 'laminas-xml_Security');
         file_put_contents($file, 'This is a remote content!');
         $xml = <<<XML
-<?xml version="1.0"?>
-<!DOCTYPE root
-[
-<!ENTITY foo SYSTEM "file://$file">
-]>
-<results>
-    <result>&foo;</result>
-</results>
-XML;
+            <?xml version="1.0"?>
+            <!DOCTYPE root
+            [
+                <!ENTITY foo SYSTEM "file://$file">
+            ]>
+            <results>
+                <result>&foo;</result>
+            </results>
+            XML;
 
         try {
-            $result = XmlSecurity::scan($xml);
+            XmlSecurity::scan($xml);
         } catch (Exception\RuntimeException $e) {
             unlink($file);
             return;
@@ -57,14 +57,14 @@ XML;
         $this->fail('An expected exception has not been raised.');
     }
 
-    public function testScanSimpleXmlResult()
+    public function testScanSimpleXmlResult(): void
     {
         $result = XmlSecurity::scan($this->getXml());
         $this->assertTrue($result instanceof SimpleXMLElement);
         $this->assertEquals($result->result, 'test');
     }
 
-    public function testScanDom()
+    public function testScanDom(): void
     {
         $dom = new DOMDocument('1.0');
         $result = XmlSecurity::scan($this->getXml(), $dom);
@@ -73,7 +73,7 @@ XML;
         $this->assertEquals($node->nodeValue, 'test');
     }
 
-    public function testScanDomHTML()
+    public function testScanDomHTML(): void
     {
         // LIBXML_HTML_NODEFDTD and LIBXML_HTML_NOIMPLIED require libxml 2.7.8+
         // http://php.net/manual/de/libxml.constants.php
@@ -85,36 +85,36 @@ XML;
 
         $dom = new DOMDocument('1.0');
         $html = <<<HTML
-<p>a simple test</p>
-HTML;
+            <p>a simple test</p>
+            HTML;
         $constants = LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED;
         $result = XmlSecurity::scanHtml($html, $dom, $constants);
         $this->assertTrue($result instanceof DOMDocument);
         $this->assertEquals($html, trim($result->saveHtml()));
     }
 
-    public function testScanInvalidXml()
+    public function testScanInvalidXml(): void
     {
         $xml = <<<XML
-<foo>test</bar>
-XML;
+            <foo>test</bar>
+            XML;
 
         $result = XmlSecurity::scan($xml);
         $this->assertFalse($result);
     }
 
-    public function testScanInvalidXmlDom()
+    public function testScanInvalidXmlDom(): void
     {
         $xml = <<<XML
-<foo>test</bar>
-XML;
+            <foo>test</bar>
+            XML;
 
         $dom = new DOMDocument('1.0');
         $result = XmlSecurity::scan($xml, $dom);
         $this->assertFalse($result);
     }
 
-    public function testScanFile()
+    public function testScanFile(): void
     {
         $file = tempnam(sys_get_temp_dir(), 'laminas-xml_Security');
         file_put_contents($file, $this->getXml());
@@ -125,18 +125,18 @@ XML;
         unlink($file);
     }
 
-    public function testScanXmlWithDTD()
+    public function testScanXmlWithDTD(): void
     {
         $xml = <<<XML
-<?xml version="1.0"?>
-<!DOCTYPE results [
-<!ELEMENT results (result+)>
-<!ELEMENT result (#PCDATA)>
-]>
-<results>
-    <result>test</result>
-</results>
-XML;
+            <?xml version="1.0"?>
+            <!DOCTYPE results [
+                <!ELEMENT results (result+)>
+                <!ELEMENT result (#PCDATA)>
+            ]>
+            <results>
+                <result>test</result>
+            </results>
+            XML;
 
         $dom = new DOMDocument('1.0');
         $result = XmlSecurity::scan($xml, $dom);
@@ -144,13 +144,13 @@ XML;
         $this->assertTrue($result->validate());
     }
 
-    protected function getXml()
+    protected function getXml(): string
     {
         return <<<XML
-<?xml version="1.0"?>
-<results>
-    <result>test</result>
-</results>
-XML;
+            <?xml version="1.0"?>
+            <results>
+                <result>test</result>
+            </results>
+            XML;
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

I'm updating logic so that it does not get used on PHP 8.0+. In PHP 8.0 and later, PHP uses libxml versions from 2.9.0, which disabled XXE by default. libxml_disable_entity_loader() is now deprecated.

The current code will throw deprecation warnings/errors and break the code. As for as far as I understand it, it the same logic as it is now disabled by default so changing this value is not needed. And also reverting the change back to its original value. 

I have opted to wrap the function calls in an if statement that checks if the current PHP version is lower than PHP 8.0. This was the easiest way I could think of to update this code without touching too much of its current behavior.

I'm not entirely sure if this is (already) wanted, this has been tested on the latest PHP 8.0 release candidate as of today. 

Also, please do let me know if you have feedback!

EDIT: 

Please note that I did not check any other part of the code, I just noticed this when running a project on PHP 8 as a test and came across this code hit on some its pages.