### PR TITLE
Add renovate security-updates-only configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>laminas/.github:renovate-config-security-updates-only"
+  ]
+}


### PR DESCRIPTION
This PR adds `renovate.json`, as suggested in https://github.com/laminas/laminas-xml/issues/12.

The file only refs the `laminas/.github` configuration.

